### PR TITLE
Rename the package to eslint-config-pagarme-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "eslint-config-pagarme",
+  "name": "eslint-config-pagarme-base",
   "version": "1.0.0",
-  "description": "Pagarme's JS ESLint config, following our styleguide",
+  "description": "Base Pagar.me's JS ESLint config, following our styleguide",
   "main": ".eslintrc.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -21,12 +21,10 @@
   },
   "homepage": "https://github.com/pagarme/javascript-style-guide#readme",
   "peerDependencies": {
-    "eslint": "^3.19.0",
-    "eslint-plugin-import": "^2.6.1"
+    "eslint": "3.19.0",
+    "eslint-plugin-import": "2.6.1"
   },
   "dependencies": {
-    "eslint": "^3.19.0",
-    "eslint-config-airbnb-base": "^11.2.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-config-airbnb-base": "11.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "Base Pagar.me's JS ESLint config, following our styleguide",
   "main": ".eslintrc.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pagarme/javascript-style-guide.git"


### PR DESCRIPTION
This PR renames the package to eslint-config-pagarme-base, as we are
planning to create the pagarme/react-style-guide, which should extend
this configuration with JSX stuff.

This idea is not new, AirBnb uses two packages too.