### PR TITLE
Modify no-use-before-define

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
         ignoreRegExpLiterals: true,
       },
     ],
+    'no-use-before-define': ['error', { 'functions': false }],
   },
 }

--- a/README.md
+++ b/README.md
@@ -141,3 +141,7 @@ Object.assign(
 
 Avoid having lines of code that are longer than 80 characters (including
 whitespace).
+
+### No use before define
+
+Create an exception for functions that are used before defined.


### PR DESCRIPTION
closes #21 

**Description:**

Create an exception for this rule, now functions can be used before defined.

Also, I don't know what kind of examples to include since both ways are correct now, for example:

Right:

```
f();
function f() {}
```

Right

```
function f() {}
f();

```

Any ideas? Thanks!!!

