### PR TITLE
Disallow multiple empty lines

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['airbnb-base'],
   rules: {
     semi: [2, 'never'],
+    'no-multiple-empty-lines': ['error', { 'max': 1 }],
     'space-before-function-paren': [2, 'always'],
     'max-params': ['error', { max: 3 }],
     'comma-dangle': [

--- a/README.md
+++ b/README.md
@@ -147,3 +147,22 @@ whitespace).
 
 A function should have no more than 3 parameters. Consider using an `options` object
 parameter if you need to pass in more values to a function.
+
+### Multiple Empty Lines
+
+Disallow the use of 2+ empty lines in the middle of the code.
+
+Wrong:
+```js
+const a = 'This is a test'
+
+
+console.log(a)
+```
+
+Right:
+```js
+const a = 'This is a test'
+
+console.log(a)
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-pagarme-base",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Base Pagar.me's JS ESLint config, following our styleguide",
   "main": ".eslintrc.js",
   "repository": {


### PR DESCRIPTION
I think disallowing multiple empty lines very useful to keep the code visually consistent.
This PR adds the following rule to classify 2+ empty lines as an error.